### PR TITLE
Nest handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ Extend DokuWiki Link syntax to
 * allow formatting title text of the link
 * specify a frame where the linked page/media to be opened, eg. in a same tab, new tab or popup window
 
+Syntax Usage/Example
+--------------------
+
+### Formatting the link text###
+You may use basic formatting for the link text. 
+[Text conversion](https://www.dokuwiki.org/wiki:syntax#text_conversions) and [smiileys](https://www.dokuwiki.org/smileys) are available in the link text.
+
+```
+[[ns:page|**internal** page]]                      internal page
+[[http://example.com|**external** link title]]     external url
+[[doku>interwiki|//interwiki// title]]             interwiki
+[[foo@example.com|contact **me**! :-)]]            mail link
+```
+
+
+### Specify how the linked page will be opened ###
+
+```
+[[ns:page target="_blank" |**internal** link title]]    open in a new tab (or window)
+[[ns:page target="_self"  |**internal** link title]]    open in same tab
+[[https://example.com target="window 600x400" |title]]  open in new window
+```
 
 ----
 Licensed under the GNU Public License (GPL) version 2

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,6 +2,6 @@ base  hyperlink
 name  HyperLink syntax
 author Satoshi Sahara
 email  sahara.satoshi@gmail.com
-date   2016-12-01
+date   2016-12-04
 desc   allow link text formattable.
 url    https://github.com/ssahara/dw-plugin-hyperlink

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,6 +2,6 @@ base  hyperlink
 name  HyperLink syntax
 author Satoshi Sahara
 email  sahara.satoshi@gmail.com
-date   2016-11-23
+date   2016-12-01
 desc   allow link text formattable.
 url    https://github.com/ssahara/dw-plugin-hyperlink

--- a/syntax/brackets.php
+++ b/syntax/brackets.php
@@ -235,11 +235,15 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
                     }
                     // image link adjustment
                     if (($i[0] == 'internalmedia') or ($i[0] == 'externalmedia')) {
-                        list($ext, $mime) = mimetype($i[1][0], false);
-                        if (substr($mime, 0, 5) == 'image') {
-                            $i[1][6] = 'nolink'; // force nolink for images
-                            if (!$text) $text = true;
-                        }
+                        // force nolink for images
+                        //list($ext, $mime) = mimetype($i[1][0], false);
+                        //if (substr($mime, 0, 5) == 'image') {
+                        //    $i[1][6] = 'nolink';
+                        //    if (!$text) $text = true;
+                        //}
+                        // force nolink for any media files
+                        $i[1][6] = 'nolink';
+                        if (!$text) $text = true;
                     }
                     call_user_func_array(array($renderer,$i[0]), $i[1]);
                 }

--- a/syntax/brackets.php
+++ b/syntax/brackets.php
@@ -13,7 +13,7 @@
  *    [[id target="_blank" | **bold text** ]]          internal page
  *    [[doku>interwiki target="_blank" | text ]]       interwiki
  *    [[http://exaple.com target="_self" | text ]]     external url
- *    [[@foo@example.com|contact **me**!]]             mail link
+ *    [[foo@example.com|contact **me**!]]              mail link
  *
  */
 
@@ -230,8 +230,18 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
         if (is_null($text) && is_array($calls)) {
             foreach ($calls as $i) {
                 if (method_exists($renderer, $i[0])) {
+                    if ($i[0] == 'cdata') {
+                        if (!$text && $i[1][0]) $text = true;
+                    }
+                    // image link adjustment
+                    if (($i[0] == 'internalmedia') or ($i[0] == 'externalmedia')) {
+                        list($ext, $mime) = mimetype($i[1][0], false);
+                        if (substr($mime, 0, 5) == 'image') {
+                            $i[1][6] = 'nolink'; // force nolink for images
+                            if (!$text) $text = true;
+                        }
+                    }
                     call_user_func_array(array($renderer,$i[0]), $i[1]);
-                    if (!$text && ($i[0] == 'cdata')) $text = true;
                 }
             }
         }
@@ -280,7 +290,5 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
         }
         return $html;
     }
-
-
 
 }

--- a/syntax/brackets.php
+++ b/syntax/brackets.php
@@ -112,8 +112,7 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
                     if (($appendTo == 'id' ) && (strpos($part, '="') !== false)) {
                         $appendTo = 'params';
                     }
-                    if (${$appendTo}) ${$appendTo} .= ' ';
-                    ${$appendTo} .= $part;
+                    ${$appendTo}.= (${$appendTo} ? ' ' : '') . $part;
                 }
 
                 // check which kind of link
@@ -155,7 +154,7 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
     function render($format, Doku_Renderer $renderer, $indata) {
         global $ID, $conf;
 
-        if ($format !== 'xhtml') return false;
+        if ($format == 'metadata') return false;
         list($state, $calls, $link_data) = $indata;
 
         if ($state !== DOKU_LEXER_EXIT) return true;

--- a/syntax/brackets.php
+++ b/syntax/brackets.php
@@ -125,7 +125,7 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
                 // intercept calls
                 $ReWriter = new Doku_Handler_Nest($handler->CallWriter, $this->mode);
                 $handler->CallWriter = & $ReWriter;
-                // don't add any plugin instruction:
+                // don't add any plugin instruction
                 return false;
 
             case DOKU_LEXER_UNMATCHED: // link text
@@ -170,10 +170,10 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
             $output = $renderer->locallink($id, $name, true);
         } elseif ($type == 'internallink') {
             $output = $renderer->internallink($id, $name, $search, true, 'content');
-            // remove span tag for current page highlight, 
-            // use $count to see whether current page wrap is necessary
+            // remove span tag for current pagename highlight,
+            // use $curid to see whether current pagename wrap is necessary
             $search = array('<span class="curid">','</span>');
-            $output = str_replace($search, '', $output, $count);
+            $output = str_replace($search, '', $output, $curid);
 
         } elseif ($type == 'externallink') {
             $output = $renderer->externallink($id, $name, true);
@@ -220,7 +220,8 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
             }
         }
 
-        if ($count) {
+        // open anchor tag <a>
+        if ($curid) {
             $html = '<span class="curid">'.$html;
         }
         $renderer->doc.= $html;
@@ -243,9 +244,9 @@ class syntax_plugin_hyperlink_brackets extends DokuWiki_Syntax_Plugin {
 
         // close </a>
         $html = '</a>';
-        if ($count) {
+        if ($curid) {
             $html = $html.'</span>';
-            unset($count);
+            unset($curid);
         }
         $renderer->doc.= $html;
         return true;

--- a/syntax/external.php
+++ b/syntax/external.php
@@ -64,7 +64,7 @@ class syntax_plugin_hyperlink_external extends DokuWiki_Syntax_Plugin {
     }
 
     /**
-     * Render output
+     * Create output
      */
     function render($format, Doku_Renderer $renderer, $data) {
         return true;


### PR DESCRIPTION
Use own ReWriter to intercept calls to ensure that link anchor is not blank and is always visible. Note the link anchor might be text, image or mixture of both. All html of link is rendered at DOKU_LEXER_EXIT stage. In order to enable Image link, instruction of internal and external media must be adjusted to have linkonly parameter. 